### PR TITLE
feat: add support for removing protected fields from response

### DIFF
--- a/lib/http/SchemaResponse.js
+++ b/lib/http/SchemaResponse.js
@@ -1,11 +1,21 @@
+const config = require('../support/config');
+
 class SchemaResponse {
   constructor(functionsRequest, res, schemaName) {
     this.functionsRequest = functionsRequest;
     this.res = res;
     this.schemaName = schemaName;
+    this.protectedFields = config.responseProtectedFields;
   }
 
+  removeProtectedFields(data) {
+    for (const field of this.protectedFields) {
+      delete data[field];
+    };
+  };
+
   json(data) {
+    this.removeProtectedFields(data);
     const schemeAndAuthority = this.functionsRequest.schemeAndAuthority();
     this.res.set('Content-Type', `application/json; charset=utf-8; profile=${schemeAndAuthority}/_schemas/${this.schemaName}`);
     this.res.end(JSON.stringify(data));

--- a/lib/support/config.js
+++ b/lib/support/config.js
@@ -22,6 +22,7 @@ module.exports = {
   defaultGlobalModules: ConfigDiscovery.getList('DEFAULT_GLOBAL_MODULES', DEFAULT_GLOBAL_MODULES),
   bodyParserLimit: process.env.BODY_PARSER_LIMIT || '1mb',
   redisConnectionTimeout: ConfigDiscovery.getInt('REDIS_CONNECTION_TIMEOUT', 2000),
+  responseProtectedFields: ConfigDiscovery.getList('RESPONSE_PROTECTED_FIELDS', ['env']),
   metric: {
     client: process.env.METRIC_CLIENT,
     udpHost: process.env.METRIC_UDP_HOST,


### PR DESCRIPTION
The SchemaResponse class now has a removeProtectedFields method that removes fields specified in the responseProtectedFields configuration option from the response data. The responseProtectedFields configuration option is a list of fields that should be removed from the response data. This allows sensitive information to be removed from the response before it is sent to the client.