### PR TITLE
feat: enable format json for log

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,14 @@ make setup
 make run
 ```
 
+## Configuration
+
+To format your log in `json`, please run:
+
+```sh
+export LOG_APP_FORMAT=json
+```
+
 ## Running locally via Docker
 ### Requirements
 - Docker 1.12+

--- a/lib/support/config.js
+++ b/lib/support/config.js
@@ -37,6 +37,7 @@ module.exports = {
     maxFullMessage: ConfigDiscovery.getInt('LOG_MAX_FULL_MESSAGE', 3000),
     maxChunkSize: ConfigDiscovery.getInt('LOG_MAX_CHUNK_SIZE', 32766),
     morganFormat: process.env.LOG_MONGAN_FORMAT || 'tiny',
+    format: process.env.LOG_APP_FORMAT || 'console',
   },
   http: {
     keepAlive: ConfigDiscovery.getBool('HTTP_KEEP_ALIVE', false),

--- a/lib/support/log.js
+++ b/lib/support/log.js
@@ -9,14 +9,21 @@ if (config.numCPUs === 1) {
   logLabel = undefined;
 }
 
+const consoleConfig = {
+  colorize: true,
+  label: logLabel,
+  level: logLevel,
+  timestamp: false,
+};
+
+if (config.log.format.toLowerCase() === 'json') {
+  consoleConfig.json = true;
+  consoleConfig.stringify = obj => JSON.stringify(obj);
+}
+
 const logger = new Logger({
   transports: [
-    new Console({
-      colorize: true,
-      label: logLabel,
-      level: logLevel,
-      timestamp: false,
-    }),
+    new Console(consoleConfig),
   ],
 });
 


### PR DESCRIPTION
to test:

```sh
export LOG_APP_FORMAT=json
make run-sandbox
```

result:

```javascript
web.1 |  raven@2.2.1 alert: no DSN provided, error reporting disabled
web.1 |  (node:17369) Warning: Accessing non-existent property 'padLevels' of module exports inside circular dependency
web.1 |  (Use `node --trace-warnings ...` to show where the warning was created)
web.1 |  {"level":"info","message":"Functions metrics is listening on port 8101"}
web.1 |  raven@2.2.1 alert: no DSN provided, error reporting disabled
web.1 |  (node:17370) Warning: Accessing non-existent property 'padLevels' of module exports inside circular dependency
web.1 |  (Use `node --trace-warnings ...` to show where the warning was created)
web.1 |  {"level":"info","message":"Functions is listening on port 8100"}
```