### PR TITLE
refactor: use request body instead of query string at /functions/pipeline

### DIFF
--- a/lib/http/SchemaResponse.js
+++ b/lib/http/SchemaResponse.js
@@ -5,13 +5,13 @@ class SchemaResponse {
     this.functionsRequest = functionsRequest;
     this.res = res;
     this.schemaName = schemaName;
-    this.allowedFields = config.responseAllowedFields;
+    this.notAllowedFields = config.responseNotAllowedFields;
   }
 
   removeNotAllowedFields(data) {
     const { env } = data;
-    if(env && env.length){
-      const fieldsToRemove = Object.keys(env.filter(field => !this.allowedFields.includes(field)));
+    if(env){
+      const fieldsToRemove = Object.keys(env).filter(field => this.notAllowedFields.includes(field));
       for (const field of fieldsToRemove) {
         delete data.env[field];
       }

--- a/lib/support/config.js
+++ b/lib/support/config.js
@@ -22,7 +22,7 @@ module.exports = {
   defaultGlobalModules: ConfigDiscovery.getList('DEFAULT_GLOBAL_MODULES', DEFAULT_GLOBAL_MODULES),
   bodyParserLimit: process.env.BODY_PARSER_LIMIT || '1mb',
   redisConnectionTimeout: ConfigDiscovery.getInt('REDIS_CONNECTION_TIMEOUT', 2000),
-  responseAllowedFields: ConfigDiscovery.getList('RESPONSE_ALLOWED_FIELDS', ['BACKSTAGE_CLIENT_ID']),
+  responseNotAllowedFields: ConfigDiscovery.getList('RESPONSE_NOT_ALLOWED_FIELDS', ['CLIENT_SECRET']),
   metric: {
     client: process.env.METRIC_CLIENT,
     udpHost: process.env.METRIC_UDP_HOST,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@globocom/backstage-functions",
-  "version": "0.6.0-rc.4",
+  "version": "0.4.2",
   "description": "Remote serverless code executor",
   "main": "index.js",
   "scripts": {

--- a/test/unit/http/routers/FunctionsRouter.test.js
+++ b/test/unit/http/routers/FunctionsRouter.test.js
@@ -363,6 +363,40 @@ describe('PUT /functions/:namespace/:id/env/:env', () => {
     });
   });
 
+  describe('when define secret env variable', () => {
+    it('should create an enviroment variable', (done) => {
+      request(routes)
+        .put('/functions/backstage/correct/env/CLIENT_SECRET')
+        .set('content-type', 'application/json')
+        .send('"FOOBAR"')
+        .expect(() => {
+          const memoryStorage = routes.get('memoryStorage');
+          expect(memoryStorage.lastEnvSet).to.be.eql({
+            namespace: 'backstage',
+            id: 'correct',
+            env: 'CLIENT_SECRET',
+            value: 'FOOBAR',
+          });
+        })
+        .expect(204, done);
+    });
+  });
+
+  describe('when get called, not return secret variable', () => {
+    it('should create an enviroment variable', (done) => {
+      request(routes)
+        .get('/functions/backstage/correct')
+        .set('content-type', 'application/json')
+        .send()
+        .expect((res) => {
+          expect(res.body.env).to.be.eql({
+            MY_VAR: 'MY VALUE',
+          });
+        })
+        .expect(200, done);
+    });
+  });
+
   describe('when the target function it\'s not exist', () => {
     it('should fail the request with 404 error', (done) => {
       request(routes)


### PR DESCRIPTION
This PR fix https://github.com/globocom/functions/issues/34 by passing the pipeline steps via request body instead of query string.